### PR TITLE
fixing contrast ratio for "midgrey" text

### DIFF
--- a/addon/styles/global.css
+++ b/addon/styles/global.css
@@ -10,6 +10,7 @@
     --red: #f05230;
     --darkgrey: #15171A;
     --midgrey: #738a94;
+    --midgrey-text: #4a5b62;
     --lightgrey: #c5d2d9;
     --whitegrey: #e5eff5;
     --pink: #fa3a57;

--- a/addon/styles/screen.css
+++ b/addon/styles/screen.css
@@ -432,7 +432,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
 .post-card-tags {
     display: block;
     margin-bottom: 4px;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.2rem;
     line-height: 1.15em;
     font-weight: 500;
@@ -585,7 +585,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
 .reading-time {
     flex-shrink: 0;
     margin-left: 20px;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.2rem;
     line-height: 33px;
     font-weight: 500;
@@ -689,7 +689,7 @@ make sure this only happens on large viewports / desktop-ish devices.
     display: flex;
     justify-content: center;
     align-items: center;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.4rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -1181,7 +1181,7 @@ Usage (In Ghost editor):
 
 .subscribe-form p {
     margin-bottom: 1em;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 2.2rem;
     line-height: 1.55em;
     letter-spacing: 0.2px;
@@ -1204,7 +1204,7 @@ Usage (In Ghost editor):
     padding: 10px;
     width: 100%;
     border: color(var(--lightgrey) l(+7%)) 1px solid;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.8rem;
     line-height: 1em;
     font-weight: normal;
@@ -1315,7 +1315,7 @@ Usage (In Ghost editor):
 
 .author-card-content p {
     margin: 0;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     line-height: 1.3em;
 }
 
@@ -1328,7 +1328,7 @@ Usage (In Ghost editor):
     display: block;
     padding: 9px 16px;
     border: color(var(--midgrey) l(+20%)) 1px solid;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.2rem;
     line-height: 1;
     font-weight: 500;
@@ -1361,7 +1361,7 @@ Usage (In Ghost editor):
 
 .post-full-authors-content p {
     margin-bottom: 0;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.4rem;
     letter-spacing: 0.2px;
     text-align: center;
@@ -2031,7 +2031,7 @@ Usage (In Ghost editor):
 
 .error-description {
     margin: 0;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 3rem;
     line-height: 1.3em;
     font-weight: 400;
@@ -2130,7 +2130,7 @@ Usage (In Ghost editor):
     padding: 14px 20px;
     width: 100%;
     border: none;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 2rem;
     line-height: 1em;
     font-weight: normal;


### PR DESCRIPTION
We should try to get this merged upstream with https://github.com/TryGhost/Casper/pull/568 and then just pull it in with the next resync 👍 