### PR TITLE
start using empress-blueprint-helpers for config editing

### DIFF
--- a/blueprints/empress-blog-casper-template/index.js
+++ b/blueprints/empress-blog-casper-template/index.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
-const recast = require('recast');
-const { readFileSync, writeFileSync } = require('fs');
+const { applyConfig } = require('empress-blueprint-helpers');
 
 module.exports = {
   description: 'The default blueprint for empress-blog-casper-template.',
@@ -9,68 +8,21 @@ module.exports = {
     // no-op
   },
 
-  afterInstall() {
-    return this.addAddonsToProject({
+  async afterInstall() {
+    await this.addAddonsToProject({
       packages: [
         'ember-responsive-image',
       ]
-    }).then(() => {
-      const builders = recast.types.builders;
+    });
 
-      let configFile = './config/environment.js'
-
-      if(this.project.isEmberCLIAddon()) {
-        configFile = './tests/dummy/config/environment.js';
-      }
-
-      const config = readFileSync(configFile);
-      const configAst = recast.parse(config);
-
-      recast.visit(configAst, {
-        visitVariableDeclaration: function (path) {
-          var node = path.node;
-
-          const env = node.declarations.find(declaration => declaration.id.name === 'ENV');
-
-          if (env) {
-            let responsiveImage = env.init.properties.find(property => property.key.value === 'responsive-image');
-
-            if(!responsiveImage) {
-              responsiveImage = builders.property(
-                'init',
-                builders.literal('responsive-image'),
-                builders.objectExpression([
-                  builders.property('init', builders.identifier('sourceDir'), builders.literal('images')),
-                  builders.property('init', builders.identifier('destinationDir'), builders.literal('responsive-images')),
-                  builders.property('init', builders.identifier('quality'), builders.literal(80)),
-                  builders.property('init', builders.identifier('supportedWidths'), builders.arrayPattern([
-                    builders.literal(2000),
-                    builders.literal(1000),
-                    builders.literal(600),
-                    builders.literal(300),
-                  ])),
-                  builders.property('init', builders.identifier('removeSourceDir'), builders.literal(false)),
-                  builders.property('init', builders.identifier('justCopy'), builders.literal(false)),
-                  builders.property('init', builders.identifier('extensions'), builders.arrayPattern([
-                    builders.literal('jpg'),
-                    builders.literal('jpeg'),
-                    builders.literal('png'),
-                    builders.literal('gif'),
-                  ])),
-                ])
-              )
-
-              env.init.properties.push(responsiveImage);
-            }
-
-            return false;
-          }
-
-          this.traverse(path);
-        }
-      });
-
-      writeFileSync(configFile, recast.print(configAst, { tabWidth: 2, quote: 'single' }).code);
+    applyConfig(this.project, 'responsive-image', {
+      sourceDir: 'images',
+      destinationDir: 'responsive-images',
+      quality: 80,
+      supportedWidths: [2000, 1000, 600, 300],
+      removeSourceDir: false,
+      justCopy: false,
+      extensions: ['jpg', 'jpeg', 'png', 'gif'],
     });
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15678,6 +15678,27 @@
         }
       }
     },
+    "empress-blueprint-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/empress-blueprint-helpers/-/empress-blueprint-helpers-1.2.1.tgz",
+      "integrity": "sha512-4MCS9uOoo6iOr1IdJ3I6AYCKVhV6V9eK8MeU50kIEm2+SA7qPti4+gQ9iAlNc0JIewAbUw+vSsv3sIsdl0elbQ==",
+      "requires": {
+        "recast": "^0.18.5"
+      },
+      "dependencies": {
+        "recast": {
+          "version": "0.18.10",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.10.tgz",
+          "integrity": "sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==",
+          "requires": {
+            "ast-types": "0.13.3",
+            "esprima": "~4.0.0",
+            "private": "^0.1.8",
+            "source-map": "~0.6.1"
+          }
+        }
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -22683,17 +22704,6 @@
       "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "recast": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.19.1.tgz",
-      "integrity": "sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==",
-      "requires": {
-        "ast-types": "0.13.3",
-        "esprima": "~4.0.0",
-        "private": "^0.1.8",
-        "source-map": "~0.6.1"
       }
     },
     "rechoir": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "ember-cli-postcss": "^6.0.1",
     "ember-composable-helpers": "^4.1.1",
     "ember-moment": "^8.0.0",
+    "empress-blueprint-helpers": "^1.2.1",
     "postcss-color-function": "^4.1.0",
     "postcss-custom-properties": "^9.1.1",
-    "postcss-easy-import": "^3.0.0",
-    "recast": "^0.19.1"
+    "postcss-easy-import": "^3.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
this is just to start using empress-blueprint-helpers for the config editing in the default blueprint 👍  this fixes the issue where install fails because something in recast has changed upstream (even in a minor version 🙃 ) 